### PR TITLE
Fixed showCourseDetails(), sidebar display upon clicking on node now works correctly

### DIFF
--- a/front-end/src/components/GraphComponent/GraphComponent.js
+++ b/front-end/src/components/GraphComponent/GraphComponent.js
@@ -93,7 +93,9 @@ export class GraphComponent extends BaseComponent {
     // Extract the node id from the element
     console.log("extracting");
     const input = clickedElement.select("text").text();
-    const match = input.match(/^[A-Za-z]*\d+/); // Matches from start to the last digit
+    console.log(input);
+    const match = input.match(/^\S+\s\d+/); // Matches from start to the last digit
+    console.log(match);
     const nodeId = match ? match[0] : null;
     console.log(nodeId);
     // Get the node data using the extracted id

--- a/front-end/src/components/SidebarComponent/SidebarComponent.js
+++ b/front-end/src/components/SidebarComponent/SidebarComponent.js
@@ -57,7 +57,7 @@ export class SidebarComponent extends BaseComponent {
       <p><strong>Prerequisites:</strong> ${prerequisites}</p>
       <p><strong>Professors:</strong></p>
       <ul>
-        ${course.professors.map((prof) => `<li>${prof}</li>`).join("")}
+        ${course.instructors}
       </ul>
     `;
   }


### PR DESCRIPTION
- Changed the regex to parse the node text correctly.
- showCourseDetails is now using `course.instructors` (used to be`course.professors`)